### PR TITLE
feat: create example of keyboard firmware using rotary encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "rotary-encoder-hal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5f10fcd6842ed448d9f5913815a343cdcbe10e53da6cac948251d529b75487"
+dependencies = [
+ "either",
+ "embedded-hal",
+]
+
+[[package]]
 name = "rp-pico"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +479,7 @@ dependencies = [
  "heapless",
  "keyberon",
  "panic-halt",
+ "rotary-encoder-hal",
  "rp-pico",
  "rp2040-hal",
  "rp2040-monotonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fugit = "0.3.6"
 keyberon = { git = "https://github.com/TeXitoi/keyberon" }
 rp2040-hal = "0.7.0"
 rp2040-monotonic = "1.2.0"
+rotary-encoder-hal = "0.5.0"
 
 [[example]]
 name = "blink-on-board-led"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,7 @@ path = "src/examples/keyberon-one-key-keyboard/example.rs"
 [[example]]
 name = "rtic-software-task"
 path = "src/examples/rtic-software-task/example.rs"
+
+[[example]]
+name = "keyberon-one-encoder-keyboard"
+path = "src/examples/keyberon-one-encoder-keyboard/example.rs"

--- a/src/examples/keyberon-one-encoder-keyboard/encoder.rs
+++ b/src/examples/keyberon-one-encoder-keyboard/encoder.rs
@@ -1,0 +1,86 @@
+use embedded_hal::digital::v2::InputPin;
+use keyberon::layout::Event;
+use rp2040_hal::gpio::{bank0::Gpio8, bank0::Gpio9, Pin, PullUpInput};
+
+const QUADRATURE_LUT: [i8; 16] = [0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0];
+
+pub struct Encoder {
+    pad_a: Pin<Gpio8, PullUpInput>,
+    pad_b: Pin<Gpio9, PullUpInput>,
+    left_event: (u8, u8),
+    right_event: (u8, u8),
+    value: u8,
+    state: u8,
+    pulses: i8,
+    resolution: i8,
+}
+
+pub enum Direction {
+    Left = 1,
+    Still = 0,
+    Right = -1,
+}
+
+impl Direction {
+    fn from_i8(value: i8) -> Direction {
+        match value {
+            1 => Direction::Left,
+            0 => Direction::Still,
+            -1 => Direction::Right,
+            _ => Direction::Still,
+        }
+    }
+}
+
+impl Encoder {
+    pub fn new(
+        pad_a: Pin<Gpio8, PullUpInput>,
+        pad_b: Pin<Gpio9, PullUpInput>,
+        left_event: (u8, u8),
+        right_event: (u8, u8),
+    ) -> Self {
+        let mut s = Self {
+            pad_a,
+            pad_b,
+            left_event,
+            right_event,
+            value: 0,
+            state: 0,
+            pulses: 0,
+            resolution: 4,
+        };
+        s.init_state();
+        s
+    }
+    fn init_state(&mut self) {
+        self.state =
+            self.pad_a.is_high().unwrap() as u8 | (self.pad_b.is_high().unwrap() as u8) << 1;
+    }
+    pub fn read_direction(&mut self) -> Direction {
+        self.state <<= 2;
+        self.state |=
+            self.pad_a.is_high().unwrap() as u8 | (self.pad_b.is_high().unwrap() as u8) << 1;
+
+        self.pulses += QUADRATURE_LUT[(self.state & 0xF) as usize];
+        if self.pulses >= self.resolution {
+            self.value += 1;
+        }
+        if self.pulses <= -self.resolution {
+            self.value -= 1;
+        }
+        Direction::from_i8(QUADRATURE_LUT[(self.state & 0xF) as usize])
+    }
+    pub fn read_events(&mut self) -> Option<[Event; 2]> {
+        match self.read_direction() {
+            Direction::Left => Some([
+                Event::Press(self.left_event.0, self.left_event.1),
+                Event::Release(self.left_event.0, self.left_event.1),
+            ]),
+            Direction::Right => Some([
+                Event::Press(self.right_event.0, self.right_event.1),
+                Event::Release(self.right_event.0, self.right_event.1),
+            ]),
+            Direction::Still => None,
+        }
+    }
+}

--- a/src/examples/keyberon-one-encoder-keyboard/example.rs
+++ b/src/examples/keyberon-one-encoder-keyboard/example.rs
@@ -1,0 +1,222 @@
+//! Single rotary encoder keyboard example using keyberon crate.
+//! Based on https://github.com/camrbuss/pinci implementation.
+
+#![no_std]
+#![no_main]
+
+mod encoder;
+
+use panic_halt as _;
+
+#[rtic::app(device = rp_pico::hal::pac, peripherals = true, dispatchers = [PIO0_IRQ_0])]
+mod app {
+    use crate::encoder::Encoder;
+    use cortex_m::prelude::_embedded_hal_watchdog_Watchdog;
+    use cortex_m::prelude::_embedded_hal_watchdog_WatchdogEnable;
+    use embedded_hal::digital::v2::OutputPin;
+    use keyberon::debounce::Debouncer;
+    use keyberon::key_code;
+    use keyberon::layout::{self, Layout};
+    use keyberon::matrix::Matrix;
+    use rp_pico::{
+        hal::{
+            self, clocks::init_clocks_and_plls, gpio::DynPin, sio::Sio, timer::Alarm, usb::UsbBus,
+            watchdog::Watchdog,
+        },
+        XOSC_CRYSTAL_FREQ,
+    };
+    use usb_device::class_prelude::*;
+    use usb_device::device::UsbDeviceState;
+
+    use fugit::MicrosDurationU32;
+
+    const SCAN_TIME_US: MicrosDurationU32 = MicrosDurationU32::micros(1000);
+
+    static mut USB_BUS: Option<usb_device::bus::UsbBusAllocator<rp2040_hal::usb::UsbBus>> = None;
+
+    pub static LAYERS: keyberon::layout::Layers<3, 1, 1> = keyberon::layout::layout! {
+        {
+            [
+                A B C
+            ]
+        }
+    };
+
+    pub const ENCODER_LEFT: (u8, u8) = (0, 1);
+    pub const ENCODER_RIGHT: (u8, u8) = (0, 2);
+
+    #[shared]
+    struct Shared {
+        usb_dev: usb_device::device::UsbDevice<'static, rp2040_hal::usb::UsbBus>,
+        usb_class: keyberon::hid::HidClass<
+            'static,
+            rp2040_hal::usb::UsbBus,
+            keyberon::keyboard::Keyboard<()>,
+        >,
+        layout: Layout<3, 1, 1>,
+        encoder: Encoder,
+    }
+
+    #[local]
+    struct Local {
+        watchdog: hal::watchdog::Watchdog,
+        matrix: Matrix<DynPin, DynPin, 1, 1>,
+        debouncer: Debouncer<[[bool; 1]; 1]>,
+        alarm: hal::timer::Alarm0,
+    }
+
+    #[init]
+    fn init(c: init::Context) -> (Shared, Local, init::Monotonics) {
+        // Soft-reset does not release the hardware spinlocks
+        // Release them now to avoid a deadlock after debug or watchdog reset
+        unsafe {
+            hal::sio::spinlock_reset();
+        }
+        let mut resets = c.device.RESETS;
+        let mut watchdog = Watchdog::new(c.device.WATCHDOG);
+        let clocks = init_clocks_and_plls(
+            XOSC_CRYSTAL_FREQ,
+            c.device.XOSC,
+            c.device.CLOCKS,
+            c.device.PLL_SYS,
+            c.device.PLL_USB,
+            &mut resets,
+            &mut watchdog,
+        )
+        .ok()
+        .unwrap();
+
+        let sio = Sio::new(c.device.SIO);
+        let pins = hal::gpio::Pins::new(
+            c.device.IO_BANK0,
+            c.device.PADS_BANK0,
+            sio.gpio_bank0,
+            &mut resets,
+        );
+
+        let mut led = pins.gpio25.into_push_pull_output();
+        led.set_high().unwrap();
+
+        // delay for power on
+        for _ in 0..1000 {
+            cortex_m::asm::nop();
+        }
+
+        let matrix: Matrix<DynPin, DynPin, 1, 1> = Matrix::new(
+            [pins.gpio13.into_pull_up_input().into()],
+            [pins.gpio14.into_push_pull_output().into()],
+        )
+        .unwrap();
+
+        let layout = Layout::new(&LAYERS);
+        let debouncer = Debouncer::new([[false; 1]; 1], [[false; 1]; 1], 20);
+
+        let encoder_a = pins.gpio8.into_pull_up_input();
+        let encoder_b = pins.gpio9.into_pull_up_input();
+        let encoder = Encoder::new(encoder_a, encoder_b, ENCODER_LEFT, ENCODER_RIGHT);
+
+        let mut timer = hal::Timer::new(c.device.TIMER, &mut resets);
+        let mut alarm = timer.alarm_0().unwrap();
+        let _ = alarm.schedule(SCAN_TIME_US);
+        alarm.enable_interrupt();
+
+        let usb_bus = UsbBusAllocator::new(UsbBus::new(
+            c.device.USBCTRL_REGS,
+            c.device.USBCTRL_DPRAM,
+            clocks.usb_clock,
+            true,
+            &mut resets,
+        ));
+        unsafe {
+            USB_BUS = Some(usb_bus);
+        }
+        let usb_class = keyberon::new_class(unsafe { USB_BUS.as_ref().unwrap() }, ());
+        let usb_dev = keyberon::new_device(unsafe { USB_BUS.as_ref().unwrap() });
+
+        // Start watchdog and feed it with the lowest priority task at 1000hz
+        watchdog.start(MicrosDurationU32::micros(10000));
+
+        (
+            Shared {
+                usb_dev,
+                usb_class,
+                layout,
+                encoder,
+            },
+            Local {
+                alarm,
+                watchdog,
+                matrix,
+                debouncer,
+            },
+            init::Monotonics(),
+        )
+    }
+
+    #[task(binds = USBCTRL_IRQ, priority = 3, shared = [usb_dev, usb_class])]
+    fn usb_rx(c: usb_rx::Context) {
+        let mut usb_d = c.shared.usb_dev;
+        let mut usb_c = c.shared.usb_class;
+        usb_d.lock(|d| {
+            usb_c.lock(|c| {
+                if d.poll(&mut [c]) {
+                    c.poll();
+                }
+            })
+        });
+    }
+
+    #[task(priority = 2, capacity = 8, shared = [usb_dev, usb_class, layout])]
+    fn handle_event(mut c: handle_event::Context, event: Option<layout::Event>) {
+        match event {
+            None => (),
+            Some(e) => {
+                c.shared.layout.lock(|l| l.event(e));
+                return;
+            }
+        };
+
+        let report: key_code::KbHidReport = c.shared.layout.lock(|l| l.keycodes().collect());
+        if !c
+            .shared
+            .usb_class
+            .lock(|k| k.device_mut().set_keyboard_report(report.clone()))
+        {
+            return;
+        }
+        if c.shared.usb_dev.lock(|d| d.state()) != UsbDeviceState::Configured {
+            return;
+        }
+        while let Ok(0) = c.shared.usb_class.lock(|k| k.write(report.as_bytes())) {}
+    }
+
+    #[task(
+        binds = TIMER_IRQ_0,
+        priority = 1,
+        shared=[encoder],
+        local = [matrix, debouncer, watchdog, alarm],
+    )]
+    fn scan_timer_irq(mut c: scan_timer_irq::Context) {
+        let alarm = c.local.alarm;
+        alarm.clear_interrupt();
+        let _ = alarm.schedule(SCAN_TIME_US);
+
+        c.local.watchdog.feed();
+        let keys_pressed = c.local.matrix.get().unwrap();
+        let deb_events = c.local.debouncer.events(keys_pressed);
+
+        for event in deb_events {
+            handle_event::spawn(Some(event)).unwrap();
+        }
+
+        c.shared.encoder.lock(|e| {
+            if let Some(events) = e.read_events() {
+                for event in events {
+                    handle_event::spawn(Some(event)).unwrap();
+                }
+            }
+        });
+
+        handle_event::spawn(None).unwrap();
+    }
+}


### PR DESCRIPTION
I'm trying to use rotary encoder to send keyboard events using the [keyberon](http://github.com/TeXitoi/keyberon/) lib, but I'm having some troubles doing that.

My goal was to get three events, or letters when interacting with the encoder.
Letter `a` when pressing the encoder.
Letter `b` when rotating it clockwise.
And letter `c` when rotating it counterclockwise.

Unfortunately only pressing the encoder works as expected.
When I try to rotate the encoder nothing is happening. 
If I keep pressing the encoder and try to rotate it sometimes I'm randomly getting `press` and `release` events with letter `a`.

Here's the preview of how I connected the rotary encoder to the board:
![IMG_2725](https://user-images.githubusercontent.com/26116041/218549528-0e7987c0-d6ea-44a3-accf-aace73405203.jpeg)


I've added code that is making the on-board led light-up when rotating the encoder clockwise and turn off when rotating counterclockwise. 
![rotary_encoder_led_test](https://user-images.githubusercontent.com/26116041/218549613-d3614b4f-c1e2-4b27-8174-10f742a85614.gif)

And the led is working as expected, so I'm assuming that with hardware everything is okay and the problem is software.

It seems that the events that I'm trying to spawn are not being handled, or maybe the approach with sending the `press` event with `release` event right after that is the problem. 
Other implementations I found online also were doing it that way, though.

The code that  is actually adding the encoder handler is [here](https://github.com/radlinskii/rustberry-pi-pico/pull/27/commits/7149812540773210d9b78444fd28b33ad6e07d2d) in the second commit of [#27](https://github.com/radlinskii/rustberry-pi-pico/pull/27) pr.

Please help!